### PR TITLE
API concurrency issue workaround

### DIFF
--- a/index_search_data.js
+++ b/index_search_data.js
@@ -165,12 +165,17 @@ Promise.all([getFiles(pagesDirectory), getFiles(productsDirectory)])
 
     console.log('Indexing pages from ' + pagesDirectory + '/ to ' + pagesIndexUri);
 
-    return Promise.all(createIndexJobs(pages, pagesIndexUri, buildPageObject))
-      .then(function() {
+    return Promise.all(createIndexJobs([pages[0]], pagesIndexUri, buildPageObject))
+      .then(() => {
+        return Promise.all(createIndexJobs(pages.slice(1), pagesIndexUri, buildPageObject));
+      })
+      .then(() => {
         console.log('Indexing products from ' + productsDirectory + '/ to ' + productsIndexUri);
-
-        return Promise.all(createIndexJobs(products, productsIndexUri, buildProductObject));
-      }, function() {
+        return Promise.all(createIndexJobs([products[0]], productsIndexUri, buildProductObject));
+      })
+      .then(() => {
+        return Promise.all(createIndexJobs(products.slice(1), productsIndexUri, buildProductObject));
+      }, () => {
         process.exit(1);
       });
   });


### PR DESCRIPTION
When multiple index requests are fired off at the same time for an index that doesn't exist, the API will try and create the index multiple times. 

We def need to change the API to handle this by making indexing asynchronous and queueing indexing requests but it's probably not going to be there in the min-vi-prod! So for the meantime, this change makes a single request per index first to create the index once, before sending the other indexing calls.
