### PR TITLE
remove old /search/ part of api url

### DIFF
--- a/app/contents/assets/js/search.js
+++ b/app/contents/assets/js/search.js
@@ -10,7 +10,7 @@
 			callback(responseData);
 		});
 
-		oReq.open('POST', 'https://api.bigwednesday.io/1/search/indexes/big-wednesday-io-' + index + '/query');
+		oReq.open('POST', 'https://api.bigwednesday.io/1/indexes/big-wednesday-io-' + index + '/query');
 		oReq.setRequestHeader('Content-Type', 'application/json')
 		oReq.setRequestHeader('Authorization', 'Bearer NG0TuV~u2ni#BP|')
 		oReq.send(JSON.stringify(search_params));

--- a/index_search_data.js
+++ b/index_search_data.js
@@ -39,7 +39,7 @@ if (preRequisiteErrors.length) {
 }
 
 var productsDirectory = pagesDirectory + '/products';
-var indexBaseUri = process.env.SEARCH_API + '/1/search/indexes/';
+var indexBaseUri = process.env.SEARCH_API + '/1/indexes/';
 var pagesIndex = 'big-wednesday-io-pages';
 var productsIndex = 'big-wednesday-io-products';
 var pagesIndexUri = indexBaseUri + pagesIndex;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app/index.html",
   "engines": {
-    "node": ">=4.1.1",
+    "node": "4.x",
     "npm": ">=3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-load-plugins": "^1.0.0-rc.1",
     "gulp-minify-css": "^1.2.1",
     "gulp-rev": "^6.0.1",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "2.0.4",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-svg-symbols": "^1.0.0",
     "gulp-uglify": "^1.4.1",


### PR DESCRIPTION
The latest version of the api excludes /search/ from the URL. We need to coordinate the merge of this with an API deployment.

cc @toboid 
